### PR TITLE
Remove erroneous debug function

### DIFF
--- a/src/utq.sh
+++ b/src/utq.sh
@@ -125,11 +125,6 @@ function ssh {
     exec $F_SSH phablet@localhost -p 10022 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"
 }
 
-function debug {
-    echo "Img file is here: ${IMG_FILE}"
-    exec $F_QEMU ${@:2}
-}
-
 function usage {
     echo "Ubuntu touch qemu - usage"
     echo "  utq start    - Stats qemu"


### PR DESCRIPTION
There was a debug function shadowing the correct one.
It was calling qemu, which doesn't make any sense and leads to erroneous behavior since the debug function is called even before the OS image is downloaded.